### PR TITLE
Maven support

### DIFF
--- a/ealvatag/pom.xml
+++ b/ealvatag/pom.xml
@@ -1,0 +1,60 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<parent>
+		<groupId>com.ealva</groupId>
+		<artifactId>ealvatag-pom</artifactId>
+		<version>0.4.7-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>ealvatag</artifactId>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>com.squareup.okio</groupId>
+			<artifactId>okio</artifactId>
+			<version>2.9.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.google.guava</groupId>
+			<artifactId>guava</artifactId>
+			<version>20.0</version>
+		</dependency>
+		<dependency>
+			<groupId>com.ealva</groupId>
+			<artifactId>ealvalog</artifactId>
+			<version>0.5.6-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.ealva</groupId>
+			<artifactId>ealvalog-core</artifactId>
+			<version>0.5.6-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>com.ealva</groupId>
+			<artifactId>ealvalog-java</artifactId>
+			<version>0.5.6-SNAPSHOT</version>
+		</dependency>
+		<dependency>
+			<groupId>junit</groupId>
+			<artifactId>junit</artifactId>
+			<version>4.13.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<version>3.6.28</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.hamcrest</groupId>
+			<artifactId>hamcrest-junit</artifactId>
+			<version>2.0.0.0</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,36 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+	<groupId>com.ealva</groupId>
+	<artifactId>ealvatag-pom</artifactId>
+	<version>0.4.7-SNAPSHOT</version>
+	<packaging>pom</packaging>
+	<name>ealvatag</name>
+
+	<properties>
+		<maven.compiler.source>11</maven.compiler.source>
+		<maven.compiler.target>11</maven.compiler.target>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
+	<repositories>
+		<repository>
+			<id>jitpack.io</id>
+			<url>https://jitpack.io</url>
+		</repository>
+		<repository>
+			<id>repo.maven.apache.org</id>
+			<url>https://repo.maven.apache.org/maven2</url>
+		</repository>
+		<repository>
+			<id>oss.sonatype.org</id>
+			<url>https://oss.sonatype.org/content/repositories/snapshots</url>
+		</repository>
+	</repositories>
+
+	<modules>
+		<module>ealvatag</module>
+	</modules>
+</project>


### PR DESCRIPTION
Added support for Maven builds.

Gradle is the new Ant - it's imperative. Declarative builds with Maven are still the best.